### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Adventures of the Go Lang in the Go Land
 # Run
 
 `go run <file>`
+
+
+[![Run on Repl.it](https://repl.it/badge/github/ricleal/GoLang)](https://repl.it/github/ricleal/GoLang)
+


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).